### PR TITLE
Moved .anything to .all and added .any

### DIFF
--- a/Sources/Routing/Register/PathComponent.swift
+++ b/Sources/Routing/Register/PathComponent.swift
@@ -8,11 +8,11 @@ public enum PathComponent: ExpressibleByStringLiteral {
     case parameter(String)
     
     /// This route will match everything that is not in other routes
-    case anything
+    case any
     
     /// This route will match and discard any number of constant components after
     /// this anything component.
-    case catchall
+    case all
 
     /// See `ExpressibleByStringLiteral`.
     public init(stringLiteral value: String) {
@@ -21,7 +21,9 @@ public enum PathComponent: ExpressibleByStringLiteral {
 }
 
 /// Shortcut for accessing `PathComponent.anything`.
-public let any: PathComponent = .anything
+public let any: PathComponent = .any
+public let all: PathComponent = .all
+
 
 extension Array where Element == PathComponent {
     /// Creates a readable representation of this array of `PathComponent`.
@@ -30,8 +32,8 @@ extension Array where Element == PathComponent {
             switch $0 {
             case .constant(let s): return s
             case .parameter(let p): return ":\(p)"
-            case .anything: return "*"
-            case .catchall: return "*"
+            case .any: return ":"
+            case .all: return "*"
             }
         }.joined(separator: "/")
     }

--- a/Sources/Routing/Register/PathComponent.swift
+++ b/Sources/Routing/Register/PathComponent.swift
@@ -8,11 +8,11 @@ public enum PathComponent: ExpressibleByStringLiteral {
     case parameter(String)
     
     /// This route will match everything that is not in other routes
-    case any
+    case anything
     
     /// This route will match and discard any number of constant components after
     /// this anything component.
-    case all
+    case catchall
 
     /// See `ExpressibleByStringLiteral`.
     public init(stringLiteral value: String) {
@@ -21,8 +21,8 @@ public enum PathComponent: ExpressibleByStringLiteral {
 }
 
 /// Shortcut for accessing `PathComponent.anything`.
-public let any: PathComponent = .any
-public let all: PathComponent = .all
+public let any: PathComponent = .anything
+public let all: PathComponent = .catchall
 
 
 extension Array where Element == PathComponent {
@@ -32,8 +32,8 @@ extension Array where Element == PathComponent {
             switch $0 {
             case .constant(let s): return s
             case .parameter(let p): return ":\(p)"
-            case .any: return ":"
-            case .all: return "*"
+            case .anything: return ":"
+            case .catchall: return "*"
             }
         }.joined(separator: "/")
     }

--- a/Sources/Routing/Register/PathComponent.swift
+++ b/Sources/Routing/Register/PathComponent.swift
@@ -22,6 +22,7 @@ public enum PathComponent: ExpressibleByStringLiteral {
 
 /// Shortcut for accessing `PathComponent.anything`.
 public let any: PathComponent = .anything
+/// Shortcut for accessing `PathComponent.catchall`.
 public let all: PathComponent = .catchall
 
 

--- a/Sources/Routing/Register/PathComponent.swift
+++ b/Sources/Routing/Register/PathComponent.swift
@@ -7,9 +7,12 @@ public enum PathComponent: ExpressibleByStringLiteral {
     /// A dynamic parameter component.
     case parameter(String)
     
+    /// This route will match everything that is not in other routes
+    case anything
+    
     /// This route will match and discard any number of constant components after
     /// this anything component.
-    case anything
+    case catchall
 
     /// See `ExpressibleByStringLiteral`.
     public init(stringLiteral value: String) {
@@ -28,6 +31,7 @@ extension Array where Element == PathComponent {
             case .constant(let s): return s
             case .parameter(let p): return ":\(p)"
             case .anything: return "*"
+            case .catchall: return "*"
             }
         }.joined(separator: "/")
     }

--- a/Sources/Routing/Routing/RouterNode.swift
+++ b/Sources/Routing/Routing/RouterNode.swift
@@ -2,30 +2,30 @@
 final class RouterNode<Output> {
     /// Kind of node
     var value: Data
-    
+
     /// All constant child nodes.
     var constants: [RouterNode<Output>]
-    
+
     /// Parameter child node, if one exists.
     var parameter: RouterNode<Output>?
-    
+
     /// Catchall node, if one exists.
     /// This node should not have any child nodes.
     var catchall: RouterNode<Output>?
-    
+
     /// Anything child node, if one exists.
     var anything: RouterNode<Output>?
-    
+
     /// This node's output
     var output: Output?
-    
+
     /// Creates a new `RouterNode`.
     init(value: Data, output: Output? = nil) {
         self.value = value
         self.output = output
         self.constants = []
     }
-    
+
     /// Fetches the child `RouterNode` for the supplied path component, or builds
     /// a new segment onto the tree if necessary.
     func buildOrFetchChild(for component: PathComponent) -> RouterNode<Output> {
@@ -36,14 +36,14 @@ final class RouterNode<Output> {
             // Performance doesn't really matter since this code should only
             // be called during registration phase.
             let value = Data(string.utf8)
-            
+
             // search for existing constant
             for constant in constants {
                 if constant.value == value {
                     return constant
                 }
             }
-            
+
             // none found, add a new node
             let node = RouterNode<Output>(value: value)
             constants.append(node)
@@ -54,7 +54,7 @@ final class RouterNode<Output> {
             // Performance doesn't really matter since this code should only
             // be called during registration phase.
             let value = Data(string.utf8)
-            
+
             let node: RouterNode<Output>
             if let parameter = self.parameter {
                 node = parameter

--- a/Sources/Routing/Routing/RouterNode.swift
+++ b/Sources/Routing/Routing/RouterNode.swift
@@ -2,27 +2,30 @@
 final class RouterNode<Output> {
     /// Kind of node
     var value: Data
-
+    
     /// All constant child nodes.
     var constants: [RouterNode<Output>]
-
+    
     /// Parameter child node, if one exists.
     var parameter: RouterNode<Output>?
-
+    
     /// Catchall node, if one exists.
     /// This node should not have any child nodes.
     var catchall: RouterNode<Output>?
-
+    
+    /// Anything child node, if one exists.
+    var anything: RouterNode<Output>?
+    
     /// This node's output
     var output: Output?
-
+    
     /// Creates a new `RouterNode`.
     init(value: Data, output: Output? = nil) {
         self.value = value
         self.output = output
         self.constants = []
     }
-
+    
     /// Fetches the child `RouterNode` for the supplied path component, or builds
     /// a new segment onto the tree if necessary.
     func buildOrFetchChild(for component: PathComponent) -> RouterNode<Output> {
@@ -33,14 +36,14 @@ final class RouterNode<Output> {
             // Performance doesn't really matter since this code should only
             // be called during registration phase.
             let value = Data(string.utf8)
-
+            
             // search for existing constant
             for constant in constants {
                 if constant.value == value {
                     return constant
                 }
             }
-
+            
             // none found, add a new node
             let node = RouterNode<Output>(value: value)
             constants.append(node)
@@ -51,7 +54,7 @@ final class RouterNode<Output> {
             // Performance doesn't really matter since this code should only
             // be called during registration phase.
             let value = Data(string.utf8)
-
+            
             let node: RouterNode<Output>
             if let parameter = self.parameter {
                 node = parameter
@@ -60,13 +63,24 @@ final class RouterNode<Output> {
                 self.parameter = node
             }
             return node
-        case .anything:
+        case .catchall:
             let node: RouterNode<Output>
             if let fallback = self.catchall {
                 node = fallback
-            } else {
+            }
+            else {
                 node = RouterNode<Output>(value: Data([.asterisk]))
                 self.catchall = node
+            }
+            return node
+        case .anything:
+            let node: RouterNode<Output>
+            if (self.anything == nil) {
+                node = RouterNode<Output>(value: Data([.asterisk]))
+                self.anything = node
+            }
+            else {
+                node = self.anything!
             }
             return node
         }

--- a/Sources/Routing/Routing/RouterNode.swift
+++ b/Sources/Routing/Routing/RouterNode.swift
@@ -63,7 +63,7 @@ final class RouterNode<Output> {
                 self.parameter = node
             }
             return node
-        case .catchall:
+        case .all:
             let node: RouterNode<Output>
             if let fallback = self.catchall {
                 node = fallback
@@ -73,7 +73,7 @@ final class RouterNode<Output> {
                 self.catchall = node
             }
             return node
-        case .anything:
+        case .any:
             let node: RouterNode<Output>
             if (self.anything == nil) {
                 node = RouterNode<Output>(value: Data([.asterisk]))

--- a/Sources/Routing/Routing/RouterNode.swift
+++ b/Sources/Routing/Routing/RouterNode.swift
@@ -74,11 +74,11 @@ final class RouterNode<Output> {
             return node
         case .anything:
             let node: RouterNode<Output>
-            if (self.anything == nil) {
+            if let anything = self.anything {
+                node = anything
+            } else {
                 node = RouterNode<Output>(value: Data([.colon]))
                 self.anything = node
-            } else {
-                node = self.anything!
             }
             return node
         }

--- a/Sources/Routing/Routing/RouterNode.swift
+++ b/Sources/Routing/Routing/RouterNode.swift
@@ -67,8 +67,7 @@ final class RouterNode<Output> {
             let node: RouterNode<Output>
             if let fallback = self.catchall {
                 node = fallback
-            }
-            else {
+            } else {
                 node = RouterNode<Output>(value: Data([.asterisk]))
                 self.catchall = node
             }

--- a/Sources/Routing/Routing/RouterNode.swift
+++ b/Sources/Routing/Routing/RouterNode.swift
@@ -63,7 +63,7 @@ final class RouterNode<Output> {
                 self.parameter = node
             }
             return node
-        case .all:
+        case .catchall:
             let node: RouterNode<Output>
             if let fallback = self.catchall {
                 node = fallback
@@ -73,13 +73,12 @@ final class RouterNode<Output> {
                 self.catchall = node
             }
             return node
-        case .any:
+        case .anything:
             let node: RouterNode<Output>
             if (self.anything == nil) {
-                node = RouterNode<Output>(value: Data([.asterisk]))
+                node = RouterNode<Output>(value: Data([.colon]))
                 self.anything = node
-            }
-            else {
+            } else {
                 node = self.anything!
             }
             return node

--- a/Sources/Routing/Routing/TrieRouter.swift
+++ b/Sources/Routing/Routing/TrieRouter.swift
@@ -9,13 +9,13 @@ public final class TrieRouter<Output> {
     ///
     /// Register new routes by using the `register(...)` method.
     public private(set) var routes: [Route<Output>]
-    
+
     /// Configured options such as case-sensitivity.
     public var options: Set<RouterOption>
-    
+
     /// The root node.
     private var root: RouterNode<Output>
-    
+
     /// Create a new `TrieRouter`.
     ///
     /// - parameters:
@@ -25,7 +25,7 @@ public final class TrieRouter<Output> {
         self.routes = []
         self.options = options
     }
-    
+
     /// Registers a new `Route` to this router.
     ///
     ///     let route = Route<Int>(path: [.constant("users"), User.parameter], output: ...)
@@ -37,18 +37,16 @@ public final class TrieRouter<Output> {
     public func register(route: Route<Output>) {
         // store the route so that we can access its metadata later if needed
         routes.append(route)
-        
+
         // start at the root of the trie branch
         var current = root
-        
-        print("adding:",route.path)
-        
+
         // for each dynamic path in the route get the appropriate
         // child generating a new one if necessary
         for component in route.path {
             current = current.buildOrFetchChild(for: component)
         }
-        
+
         // after iterating over all path components, we can set the output
         // on the current node
         debugOnly {
@@ -58,7 +56,7 @@ public final class TrieRouter<Output> {
         }
         current.output = route.output
     }
-    
+
     /// Routes a `path`, returning the best-matching output and collecting any dynamic parameters.
     ///
     ///     var params = Parameters()
@@ -71,7 +69,7 @@ public final class TrieRouter<Output> {
     public func route<C>(path: [C], parameters: inout Parameters) -> Output? where C: RoutableComponent {
         // always start at the root node
         var currentNode: RouterNode = root
-        
+
         // traverse the string path supplied
         search: for path in path {
             // check the constants first
@@ -81,7 +79,7 @@ public final class TrieRouter<Output> {
                     continue search
                 }
             }
-            
+
             // no constants matched, check for dynamic members
             if let parameter = currentNode.parameter {
                 // if no constant routes were found that match the path, but
@@ -94,23 +92,23 @@ public final class TrieRouter<Output> {
                 currentNode = parameter
                 continue search
             }
-            
+
             // check for anythings
             if let anything = currentNode.anything {
                 currentNode = anything
                 continue search
             }
-            
+
             // no constants or dynamic members, check for catchall
             if let catchall = currentNode.catchall {
                 // there is a catchall and it is final, short-circuit to its output
                 return catchall.output
             }
-            
+
             // no matches, stop searching
             return nil
         }
-        
+
         // return the currently resolved responder if there hasn't been an early exit.
         return currentNode.output
     }

--- a/Sources/Routing/Routing/TrieRouter.swift
+++ b/Sources/Routing/Routing/TrieRouter.swift
@@ -9,13 +9,13 @@ public final class TrieRouter<Output> {
     ///
     /// Register new routes by using the `register(...)` method.
     public private(set) var routes: [Route<Output>]
-
+    
     /// Configured options such as case-sensitivity.
     public var options: Set<RouterOption>
-
+    
     /// The root node.
     private var root: RouterNode<Output>
-
+    
     /// Create a new `TrieRouter`.
     ///
     /// - parameters:
@@ -25,7 +25,7 @@ public final class TrieRouter<Output> {
         self.routes = []
         self.options = options
     }
-
+    
     /// Registers a new `Route` to this router.
     ///
     ///     let route = Route<Int>(path: [.constant("users"), User.parameter], output: ...)
@@ -37,16 +37,18 @@ public final class TrieRouter<Output> {
     public func register(route: Route<Output>) {
         // store the route so that we can access its metadata later if needed
         routes.append(route)
-
+        
         // start at the root of the trie branch
         var current = root
-
+        
+        print("adding:",route.path)
+        
         // for each dynamic path in the route get the appropriate
         // child generating a new one if necessary
         for component in route.path {
             current = current.buildOrFetchChild(for: component)
         }
-
+        
         // after iterating over all path components, we can set the output
         // on the current node
         debugOnly {
@@ -56,7 +58,7 @@ public final class TrieRouter<Output> {
         }
         current.output = route.output
     }
-
+    
     /// Routes a `path`, returning the best-matching output and collecting any dynamic parameters.
     ///
     ///     var params = Parameters()
@@ -69,7 +71,7 @@ public final class TrieRouter<Output> {
     public func route<C>(path: [C], parameters: inout Parameters) -> Output? where C: RoutableComponent {
         // always start at the root node
         var currentNode: RouterNode = root
-
+        
         // traverse the string path supplied
         search: for path in path {
             // check the constants first
@@ -79,7 +81,7 @@ public final class TrieRouter<Output> {
                     continue search
                 }
             }
-
+            
             // no constants matched, check for dynamic members
             if let parameter = currentNode.parameter {
                 // if no constant routes were found that match the path, but
@@ -92,13 +94,19 @@ public final class TrieRouter<Output> {
                 currentNode = parameter
                 continue search
             }
-
+            
+            // check for anythings
+            if let anything = currentNode.anything {
+                currentNode = anything
+                continue search
+            }
+            
             // no constants or dynamic members, check for catchall
             if let catchall = currentNode.catchall {
-                // there is a catchall, short-circuit to its output
+                // there is a catchall and it is final, short-circuit to its output
                 return catchall.output
             }
-
+            
             // no matches, stop searching
             return nil
         }

--- a/Tests/RoutingTests/RouterTests.swift
+++ b/Tests/RoutingTests/RouterTests.swift
@@ -36,12 +36,12 @@ class RouterTests: XCTestCase {
     }
 
     func testAnyRouting() throws {
-        let route0 = Route<Int>(path: [.constant("a"), .any], output: 0)
-        let route1 = Route<Int>(path: [.constant("b"), .parameter("1"), .any], output: 1)
-        let route2 = Route<Int>(path: [.constant("c"), .parameter("1"), .parameter("2"), .any], output: 2)
+        let route0 = Route<Int>(path: [.constant("a"), any], output: 0)
+        let route1 = Route<Int>(path: [.constant("b"), .parameter("1"), any], output: 1)
+        let route2 = Route<Int>(path: [.constant("c"), .parameter("1"), .parameter("2"), any], output: 2)
         let route3 = Route<Int>(path: [.constant("d"), .parameter("1"), .parameter("2")], output: 3)
-        let route4 = Route<Int>(path: [.constant("e"), .parameter("1"), .all], output: 4)
-        let route5 = Route<Int>(path: [.any, .constant("e"), .parameter("1")], output: 5)
+        let route4 = Route<Int>(path: [.constant("e"), .parameter("1"), all], output: 4)
+        let route5 = Route<Int>(path: [any, .constant("e"), .parameter("1")], output: 5)
 
         let router = TrieRouter<Int>()
         router.register(route: route0)

--- a/Tests/RoutingTests/RouterTests.swift
+++ b/Tests/RoutingTests/RouterTests.swift
@@ -36,12 +36,12 @@ class RouterTests: XCTestCase {
     }
 
     func testAnyRouting() throws {
-        let route0 = Route<Int>(path: [.constant("a"), .anything], output: 0)
-        let route1 = Route<Int>(path: [.constant("b"), .parameter("1"), .anything], output: 1)
-        let route2 = Route<Int>(path: [.constant("c"), .parameter("1"), .parameter("2"), .anything], output: 2)
+        let route0 = Route<Int>(path: [.constant("a"), .any], output: 0)
+        let route1 = Route<Int>(path: [.constant("b"), .parameter("1"), .any], output: 1)
+        let route2 = Route<Int>(path: [.constant("c"), .parameter("1"), .parameter("2"), .any], output: 2)
         let route3 = Route<Int>(path: [.constant("d"), .parameter("1"), .parameter("2")], output: 3)
-        let route4 = Route<Int>(path: [.constant("e"), .parameter("1"), .catchall], output: 4)
-        let route5 = Route<Int>(path: [.anything, .constant("e"), .parameter("1")], output: 5)
+        let route4 = Route<Int>(path: [.constant("e"), .parameter("1"), .all], output: 4)
+        let route5 = Route<Int>(path: [.any, .constant("e"), .parameter("1")], output: 5)
 
         let router = TrieRouter<Int>()
         router.register(route: route0)

--- a/Tests/RoutingTests/RouterTests.swift
+++ b/Tests/RoutingTests/RouterTests.swift
@@ -40,7 +40,8 @@ class RouterTests: XCTestCase {
         let route1 = Route<Int>(path: [.constant("b"), .parameter("1"), .anything], output: 1)
         let route2 = Route<Int>(path: [.constant("c"), .parameter("1"), .parameter("2"), .anything], output: 2)
         let route3 = Route<Int>(path: [.constant("d"), .parameter("1"), .parameter("2")], output: 3)
-        let route4 = Route<Int>(path: [.constant("e"), .parameter("1"), .anything], output: 4)
+        let route4 = Route<Int>(path: [.constant("e"), .parameter("1"), .catchall], output: 4)
+        let route5 = Route<Int>(path: [.anything, .constant("e"), .parameter("1")], output: 5)
 
         let router = TrieRouter<Int>()
         router.register(route: route0)
@@ -48,6 +49,7 @@ class RouterTests: XCTestCase {
         router.register(route: route2)
         router.register(route: route3)
         router.register(route: route4)
+        router.register(route: route5)
 
         var params = Parameters()
         XCTAssertEqual(router.route(path: ["a", "b"], parameters: &params), 0)
@@ -64,6 +66,9 @@ class RouterTests: XCTestCase {
         XCTAssertNil(router.route(path: ["d", "a", "b", "c"], parameters: &params))
         XCTAssertNil(router.route(path: ["d", "a"], parameters: &params))
         XCTAssertEqual(router.route(path: ["e", "1", "b", "a"], parameters: &params), 4)
+        XCTAssertEqual(router.route(path: ["f", "e", "1"], parameters: &params), 5)
+        XCTAssertEqual(router.route(path: ["g", "e", "1"], parameters: &params), 5)
+        XCTAssertEqual(router.route(path: ["g", "e", "1"], parameters: &params), 5)
     }
 
     func testRouterSuffixes() throws {


### PR DESCRIPTION
WIth the newest version old routes were broken. Specifically the ones using PathComponent.anything.

The way it was working before and broken now was:
`[PathComponent.anything, "test1", "test2"]`


With the newest update it is assumed that `.anything` is exclusively used at the end of an route as the last element, without any further paths after that.

This PR includes necessary changes to re-add the previous behavior by introducing a new type. The new type is called `.anything` whereas the current `.anything` is renamed to .catchall, to prevent confusion.

There should be no performance difference since the tree is parsed as with other components and I don't see a reason why we should not have the option to use `.anything` in different places other than the end.