### PR TITLE
Removed type comparison and switched to conformance.

### DIFF
--- a/Sources/Routing/Register/PathComponent.swift
+++ b/Sources/Routing/Register/PathComponent.swift
@@ -60,7 +60,7 @@ extension String: PathComponentsRepresentable {
     }
 }
 
-extension Array: PathComponentsRepresentable where Element == PathComponentsRepresentable {
+extension Array where Element: PathComponentsRepresentable {
     /// Converts self to an array of `PathComponent`.
     public func convertToPathComponents() -> [PathComponent] {
         return flatMap { $0.convertToPathComponents() }


### PR DESCRIPTION
This would remove this compiler error where it looks like it makes sense because `String` conforms to `PathComponentRepresentable` but is unable to have an `[String]` conform to the same protocol.
<img width="930" alt="screen_shot_2018-07-13_at_00 38 10" src="https://user-images.githubusercontent.com/12012815/42664353-525f82f8-8608-11e8-9a6b-4360fedb77c3.png">
