### PR TITLE
Add a Mount RouteOption

### DIFF
--- a/Sources/Routing/Register/RouterOption.swift
+++ b/Sources/Routing/Register/RouterOption.swift
@@ -3,4 +3,24 @@ public enum RouterOption {
     /// If set, this will cause the router's route matching to be case-insensitive.
     /// - note: Case-insensitive routing may be less performant than case-sensitive routing.
     case caseInsensitive
+    
+    /// If set, this the mount path will be prepended to all registered routes
+    case mount([PathComponent])
+}
+
+extension RouterOption: Hashable {
+    
+    public var hashValue: Int {
+        switch self {
+        case .caseInsensitive:
+            return 0
+        case .mount(let path):
+            return path.readable.hashValue
+        }
+    }
+    
+    public static func == (lhs: RouterOption, rhs: RouterOption) -> Bool {
+        return lhs.hashValue == rhs.hashValue
+    }
+    
 }

--- a/Sources/Routing/Routing/TrieRouter.swift
+++ b/Sources/Routing/Routing/TrieRouter.swift
@@ -35,6 +35,16 @@ public final class TrieRouter<Output> {
     /// - parameters:
     ///     - route: `Route` to register to this router.
     public func register(route: Route<Output>) {
+        
+        for option in options {
+            switch option {
+            case .mount(let mountPath):
+                // Insert path at element 1 as the first element is reserved for GET, PUT, DELETE, etc
+                route.path.insert(contentsOf: mountPath, at: 1)
+            default: break
+            }
+        }
+        
         // store the route so that we can access its metadata later if needed
         routes.append(route)
 


### PR DESCRIPTION
It would be useful if a base mount path could be applied to all routes. For example, an API may way to house all its routes behind `/api` or even `/api/v1`. This would be the mount path the all the routes are served on. By adding a new `RouteOption` this can easily be done.

Note, To add a case for `mount([PathComponent])` it was required that `RouteOption` conform to `Hashable`. 