### PR TITLE
Proof of concept for typed routing

### DIFF
--- a/Sources/Routing/Parameter/Parameter.swift
+++ b/Sources/Routing/Parameter/Parameter.swift
@@ -7,7 +7,7 @@ import Foundation
 ///         return "user id: \(id)"
 ///     }
 ///
-/// Uspublic e the static `parameter` property to generate a `PathComponent` for this type.
+/// Use the static `parameter` property to generate a `PathComponent` for this type.
 public protocol Parameter {
     /// The type this parameter will convert to once it is looked up.
     /// Most types like `String` and `Int` will simply return self, but some
@@ -43,16 +43,15 @@ public protocol Parameter {
 
 extension Parameter where Self: LosslessDataConvertible {
     public typealias ParameterType = Self
-    /// Creates a `PathComponent` for this type which can be used
-    /// when registering routes to a router.
+   
+    /// See `Parameter`.
     public static var parameter: PathComponent {
         return .parameter(routingSlug, Self.self)
     }
 }
 
 extension Parameter {
-    /// Creates a `PathComponent` for this type which can be used
-    /// when registering routes to a router.
+    /// See `Parameter`.
     public static var parameter: PathComponent {
         return .parameter(routingSlug, ParameterType.self)
     }

--- a/Sources/Routing/Parameter/Parameter.swift
+++ b/Sources/Routing/Parameter/Parameter.swift
@@ -107,7 +107,7 @@ extension BinaryFloatingPoint {
     }
 }
 
-extension Float: Parameter, LosslessDataConvertible{ }
+extension Float: Parameter, LosslessDataConvertible { }
 extension Double: Parameter, LosslessDataConvertible { }
 
 extension UUID: Parameter, LosslessDataConvertible {

--- a/Sources/Routing/Parameter/Parameter.swift
+++ b/Sources/Routing/Parameter/Parameter.swift
@@ -119,17 +119,5 @@ extension UUID: Parameter, LosslessDataConvertible {
 
         return uuid
     }
-    
-    public init?(_ data: Data) {
-        guard let number = (data.withUnsafeBytes {
-            (pointer: UnsafePointer<UUID>) -> UUID? in
-            if MemoryLayout<UUID>.size != data.count { return nil }
-            return pointer.pointee
-        }) else {
-            return nil
-        }
-        
-        self = number
-    }
 }
 

--- a/Sources/Routing/Register/PathComponent.swift
+++ b/Sources/Routing/Register/PathComponent.swift
@@ -8,7 +8,7 @@ public protocol LosslessDataConvertible {
 
 public extension LosslessDataConvertible {
     init?(_ data: Data) {
-        guard data.count < MemoryLayout<Self>.size else {
+        guard data.count <= MemoryLayout<Self>.size else {
             return nil
         }
         self = data.withUnsafeBytes { $0.pointee }

--- a/Sources/Routing/Register/PathComponent.swift
+++ b/Sources/Routing/Register/PathComponent.swift
@@ -1,3 +1,60 @@
+import Foundation
+
+/// A type that can be created from `Data` in a lossless, unambiguous way.
+public protocol LosslessDataConvertible {
+    /// Losslessly converts `Data` to this type.
+    init?(_ data: Data)
+}
+
+public extension LosslessDataConvertible {
+    init?(_ data: Data) {
+        guard data.count < MemoryLayout<Self>.size else {
+            return nil
+        }
+        self = data.withUnsafeBytes { $0.pointee }
+    }
+}
+
+/// A type that can be converted to `Data`
+public protocol CustomDataConvertible {
+    /// Losslessly converts this type to `Data`.
+    func convertToData() -> Data
+}
+
+extension Data {
+    /// Converts this `Data` to a `LosslessDataConvertible` type.
+    ///
+    ///     let string = Data([0x68, 0x69]).convert(to: String.self)
+    ///     print(string) // "hi"
+    ///
+    /// - parameters:
+    ///     - type: The `LosslessDataConvertible` to convert to.
+    /// - returns: Instance of the `LosslessDataConvertible` type.
+    public func convert<T>(to type: T.Type = T.self) -> T? where T: LosslessDataConvertible {
+        return T.init(self)
+    }
+}
+
+extension String: LosslessDataConvertible, CustomDataConvertible {
+    /// Converts this `String` to data using `.utf8`.
+    public func convertToData() -> Data {
+        return Data(utf8)
+    }
+    
+    /// Converts `Data` to a `utf8` encoded String.
+    ///
+    /// - throws: Error if String is not UTF8 encoded.
+    public init?(_ data: Data) {
+        guard let string = String(data: data, encoding: .utf8) else {
+            /// FIXME: string convert _from_ data is not actually lossless.
+            /// this should really only conform to a `LosslessDataRepresentable` protocol.
+            return nil
+        }
+        self = string
+    }
+}
+
+
 /// A single path component of a `Route`. An array of these components describes
 /// a route's path, including which parts are constant and which parts are dynamic (parameters).
 public enum PathComponent: ExpressibleByStringLiteral {
@@ -5,7 +62,7 @@ public enum PathComponent: ExpressibleByStringLiteral {
     case constant(String)
 
     /// A dynamic parameter component.
-    case parameter(String)
+    case parameter(String, LosslessDataConvertible.Type)
     
     /// This route will match everything that is not in other routes
     case anything

--- a/Sources/Routing/Routing/RouterNode.swift
+++ b/Sources/Routing/Routing/RouterNode.swift
@@ -9,7 +9,7 @@ final class RouterNode<Output> {
     var constants: [RouterNode<Output>]
 
     /// Parameter child node, if one exists.
-    var parameter: RouterNode<Output>?
+    var parameter: (node: RouterNode<Output>, type: LosslessDataConvertible.Type)?
 
     /// Catchall node, if one exists.
     /// This node should not have any child nodes.
@@ -50,19 +50,20 @@ final class RouterNode<Output> {
             let node = RouterNode<Output>(value: value)
             constants.append(node)
             return node
-        case .parameter(let string):
+        case .parameter(let string, let type):
             // Do string <-> data conversion here
             //
             // Performance doesn't really matter since this code should only
             // be called during registration phase.
+            // TODO: Do we actually do anything with this?
             let value = Data(string.utf8)
 
             let node: RouterNode<Output>
             if let parameter = self.parameter {
-                node = parameter
+                node = parameter.node
             } else {
                 node = RouterNode<Output>(value: value)
-                self.parameter = node
+                self.parameter = (node, type) 
             }
             return node
         case .catchall:

--- a/Tests/RoutingTests/RouterTests.swift
+++ b/Tests/RoutingTests/RouterTests.swift
@@ -31,11 +31,11 @@ class RouterTests: XCTestCase {
 
     func testAnyRouting() throws {
         let route0 = Route<Int>(path: [.constant("a"), any], output: 0)
-        let route1 = Route<Int>(path: [.constant("b"), .parameter("1"), any], output: 1)
-        let route2 = Route<Int>(path: [.constant("c"), .parameter("1"), .parameter("2"), any], output: 2)
-        let route3 = Route<Int>(path: [.constant("d"), .parameter("1"), .parameter("2")], output: 3)
-        let route4 = Route<Int>(path: [.constant("e"), .parameter("1"), all], output: 4)
-        let route5 = Route<Int>(path: [any, .constant("e"), .parameter("1")], output: 5)
+        let route1 = Route<Int>(path: [.constant("b"), .parameter("1", String.self), any], output: 1)
+        let route2 = Route<Int>(path: [.constant("c"), .parameter("1", Int.self), .parameter("2", Int.self), any], output: 2)
+        let route3 = Route<Int>(path: [.constant("d"), .parameter("1", String.self), .parameter("2", String.self)], output: 3)
+        let route4 = Route<Int>(path: [.constant("e"), .parameter("1", Int.self), all], output: 4)
+        let route5 = Route<Int>(path: [any, .constant("e"), .parameter("1", Int.self)], output: 5)
 
         let router = TrieRouter<Int>()
         router.register(route: route0)
@@ -64,6 +64,21 @@ class RouterTests: XCTestCase {
         XCTAssertEqual(router.route(path: ["g", "e", "1"], parameters: &params), 5)
         XCTAssertEqual(router.route(path: ["g", "e", "1"], parameters: &params), 5)
     }
+    
+//    func testTempRoutes() throws {
+//        let route4 = Route<Int>(path: [.constant("e"), .parameter("1", Int.self), all], output: 4)
+//        let route5 = Route<Int>(path: [any, .constant("e"), .parameter("1", Int.self)], output: 5)
+//        
+//        let router = TrieRouter<Int>()
+//        router.register(route: route4)
+//        router.register(route: route5)
+//        
+//        var params = Parameters()
+//        XCTAssertEqual(router.route(path: ["e", "1", "b", "a"], parameters: &params), 4)
+//        XCTAssertEqual(router.route(path: ["f", "e", "1"], parameters: &params), 5)
+//        XCTAssertEqual(router.route(path: ["g", "e", "1"], parameters: &params), 5)
+//        XCTAssertEqual(router.route(path: ["g", "e", "1"], parameters: &params), 5)
+//    }
 
     func testRouterSuffixes() throws {
         let route1 = Route<Int>(path: [.constant("a")], output: 1)
@@ -100,7 +115,7 @@ class RouterTests: XCTestCase {
 
     func testDocs2() throws {
         let router = TrieRouter(String.self)
-        router.register(route: Route(path: [.constant("users"), .parameter("user_id")], output: "show_user"))
+        router.register(route: Route(path: [.constant("users"), .parameter("user_id", Int.self)], output: "show_user"))
 
         var params = Parameters()
         _ = router.route(path: ["users", "42"], parameters: &params)
@@ -117,6 +132,8 @@ class RouterTests: XCTestCase {
 }
 
 final class User: Parameter {
+    typealias ParameterType = String
+    
     var name: String
 
     init(name: String) {

--- a/Tests/RoutingTests/RouterTests.swift
+++ b/Tests/RoutingTests/RouterTests.swift
@@ -64,21 +64,6 @@ class RouterTests: XCTestCase {
         XCTAssertEqual(router.route(path: ["g", "e", "1"], parameters: &params), 5)
         XCTAssertEqual(router.route(path: ["g", "e", "1"], parameters: &params), 5)
     }
-    
-//    func testTempRoutes() throws {
-//        let route4 = Route<Int>(path: [.constant("e"), .parameter("1", Int.self), all], output: 4)
-//        let route5 = Route<Int>(path: [any, .constant("e"), .parameter("1", Int.self)], output: 5)
-//        
-//        let router = TrieRouter<Int>()
-//        router.register(route: route4)
-//        router.register(route: route5)
-//        
-//        var params = Parameters()
-//        XCTAssertEqual(router.route(path: ["e", "1", "b", "a"], parameters: &params), 4)
-//        XCTAssertEqual(router.route(path: ["f", "e", "1"], parameters: &params), 5)
-//        XCTAssertEqual(router.route(path: ["g", "e", "1"], parameters: &params), 5)
-//        XCTAssertEqual(router.route(path: ["g", "e", "1"], parameters: &params), 5)
-//    }
 
     func testRouterSuffixes() throws {
         let route1 = Route<Int>(path: [.constant("a")], output: 1)


### PR DESCRIPTION
Notes:

This is really quick and dirty. I'll leave notes in places that likely need cleanup, but users can now provide the type they expect to receive in parameters, and route matching will fail if a parameter can't be casted to the expected type (sorta).

I realized part of the way through that we don't need to actually go through the work of converting from Data to another type, we just need to run checks on the data to ensure conversion is possible. I don't know if that would be easier or less intensive, but maybe some heuristics could be created to do the necessary checks? 