### PR TITLE
remove constant value from node in radix tree

### DIFF
--- a/Sources/RoutingKit/Routing/TrieRouter+Node.swift
+++ b/Sources/RoutingKit/Routing/TrieRouter+Node.swift
@@ -78,7 +78,6 @@ extension TrieRouter {
         
         var description: String {
             var desc: [String] = []
-            // desc.append("→ " + self.value)
             if let (name, parameter) = self.parameter {
                 desc.append("→ \(name)")
                 desc.append(parameter.description.indented())

--- a/Sources/RoutingKit/Routing/TrieRouter+Node.swift
+++ b/Sources/RoutingKit/Routing/TrieRouter+Node.swift
@@ -3,14 +3,11 @@ import Foundation
 extension TrieRouter {
     /// A single node of the `Router`s trie tree of routes.
     final class Node: CustomStringConvertible {
-        /// Kind of node
-        var value: String
-        
         /// All constant child nodes.
         var constants: [String: Node]
         
         /// Parameter child node, if one exists.
-        var parameter: Node?
+        var parameter: (String, Node)?
         
         /// Catchall node, if one exists.
         /// This node should not have any child nodes.
@@ -23,8 +20,7 @@ extension TrieRouter {
         var output: Output?
         
         /// Creates a new `RouterNode`.
-        init(value: String, output: Output? = nil) {
-            self.value = value
+        init(output: Output? = nil) {
             self.output = output
             self.constants = [String: Node]()
         }
@@ -46,16 +42,17 @@ extension TrieRouter {
                 }
                 
                 // none found, add a new node
-                let node = Node(value: string)
+                let node = Node()
                 self.constants[string] = node
                 return node
             case .parameter(let string):
                 let node: Node
-                if let parameter = self.parameter {
-                    node = parameter
+                if let (name, existing) = self.parameter {
+                    node = existing
+                    assert(name == string, "router type mis-match \(name) != \(string)")
                 } else {
-                    node = Node(value: string)
-                    self.parameter = node
+                    node = Node()
+                    self.parameter = (string, node)
                 }
                 return node
             case .catchall:
@@ -63,7 +60,7 @@ extension TrieRouter {
                 if let fallback = self.catchall {
                     node = fallback
                 } else {
-                    node = Node(value: "*")
+                    node = Node()
                     self.catchall = node
                 }
                 return node
@@ -72,7 +69,7 @@ extension TrieRouter {
                 if let anything = self.anything {
                     node = anything
                 } else {
-                    node = Node(value: ":")
+                    node = Node()
                     self.anything = node
                 }
                 return node
@@ -81,10 +78,22 @@ extension TrieRouter {
         
         var description: String {
             var desc: [String] = []
-            desc.append("→ " + self.value)
-            let children = self.constants.values + [self.parameter, self.catchall, self.anything].compactMap { $0 }
-            for child in children {
-                desc.append(child.description.indented())
+            // desc.append("→ " + self.value)
+            if let (name, parameter) = self.parameter {
+                desc.append("→ \(name)")
+                desc.append(parameter.description.indented())
+            }
+            if let catchall = self.catchall {
+                desc.append("→ *")
+                desc.append(catchall.description.indented())
+            }
+            if let anything = self.anything {
+                desc.append("→ :")
+                desc.append(anything.description.indented())
+            }
+            for (name, constant) in self.constants {
+                desc.append("→ \(name)")
+                desc.append(constant.description.indented())
             }
             return desc.joined(separator: "\n")
         }

--- a/Sources/RoutingKit/Routing/TrieRouter.swift
+++ b/Sources/RoutingKit/Routing/TrieRouter.swift
@@ -18,7 +18,7 @@ public final class TrieRouter<Output>: CustomStringConvertible {
     /// - parameters:
     ///     - options: Configured options such as case-sensitivity.
     public init(_ type: Output.Type = Output.self, options: Set<RouterOption> = []) {
-        self.root = Node(value: "/")
+        self.root = Node()
         self.options = options
     }
 
@@ -74,11 +74,11 @@ public final class TrieRouter<Output>: CustomStringConvertible {
             }
 
             // no constants matched, check for dynamic members
-            if let parameter = currentNode.parameter {
+            if let (name, parameter) = currentNode.parameter {
                 // if no constant routes were found that match the path, but
                 // a dynamic parameter child was found, we can use it
                 let value = ParameterValue(
-                    slug: parameter.value,
+                    slug: name,
                     value: path
                 )
                 parameters.values.append(value)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,7 @@
 #if os(Linux)
 
 import XCTest
-@testable import RoutingKitTests
+import RoutingKitTests
 
 XCTMain([
     testCase(RouterTests.allTests),

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -108,8 +108,7 @@ public final class RouterTests: XCTestCase {
     // MARK: Performance
     
     public func testCaseSensitivePerformance() throws {
-        print()
-        print("[EXPECTED] average: 0.024, relative standard deviation: 5.642%")
+        guard performance(0.024) else { return }
         let router = TrieRouter(String.self)
         for letter in ["a", "b", "c", "d", "e" , "f", "g"] {
             router.register(route: Route(path: [
@@ -127,8 +126,7 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testCaseInsensitivePerformance() throws {
-        print()
-        print("[EXPECTED] average: 0.032, relative standard deviation: 0.869%")
+        guard performance(0.032) else { return }
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["a", "b", "c", "d", "e" , "f", "g"] {
             router.register(route: Route(path: [
@@ -146,8 +144,7 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testCaseInsensitiveRoutingMatchFirstPerformance() throws {
-        print()
-        print("[EXPECTED] average: 0.045, relative standard deviation: 0.264%")
+        guard performance(0.045) else { return }
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["aaaaaaaa", "aaaaaaab", "aaaaaaac", "aaaaaaad", "aaaaaaae" , "aaaaaaaf", "aaaaaaag"] {
             router.register(route: Route(path: [
@@ -165,8 +162,7 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testCaseInsensitiveRoutingMatchLastPerformance() throws {
-        print()
-        print("[EXPECTED] average: 0.046, relative standard deviation: 0.086%")
+        guard performance(0.046) else { return }
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["aaaaaaaa", "aaaaaaab", "aaaaaaac", "aaaaaaad", "aaaaaaae" , "aaaaaaaf", "aaaaaaag"] {
             router.register(route: Route(path: [
@@ -184,8 +180,7 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testMinimalRouterCaseSensitivePerformance() throws {
-        print()
-        print("[EXPECTED] average: 0.016, relative standard deviation: 0.046%")
+        guard performance(0.016) else { return }
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["a"] {
             router.register(route: Route(path: [
@@ -202,8 +197,7 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testMinimalRouterCaseInsensitivePerformance() throws {
-        print()
-        print("[EXPECTED] average: 0.021, relative standard deviation: 0.800%")
+        guard performance(0.021) else { return }
         let router = TrieRouter.init(String.self)
         for letter in ["a"] {
             router.register(route: Route(path: [
@@ -221,8 +215,7 @@ public final class RouterTests: XCTestCase {
     
     
     public func testMinimalEarlyFailPerformance() throws {
-        print()
-        print("[EXPECTED] average: 0.013, relative standard deviation: 4.608%")
+        guard performance(0.013) else { return }
         let router = TrieRouter.init(String.self)
         for letter in ["aaaaaaaaaaaaaa"] {
             router.register(route: Route(path: [
@@ -253,6 +246,14 @@ public final class RouterTests: XCTestCase {
         ("testMinimalRouterCaseSensitivePerformance", testMinimalRouterCaseSensitivePerformance),
         ("testMinimalEarlyFailPerformance", testMinimalEarlyFailPerformance),
     ]
+}
+
+func performance(_ seconds: Double) -> Bool {
+    guard !_isDebugAssertConfiguration() else {
+        return false
+    }
+    print()
+    print("[PERFORMANCE TEST] expected \(seconds) seconds")
 }
 
 final class User: Parameter {

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -108,7 +108,7 @@ public final class RouterTests: XCTestCase {
     // MARK: Performance
     
     public func testCaseSensitivePerformance() throws {
-        guard performance(0.024) else { return }
+        guard performance(expected: 0.024) else { return }
         let router = TrieRouter(String.self)
         for letter in ["a", "b", "c", "d", "e" , "f", "g"] {
             router.register(route: Route(path: [
@@ -126,7 +126,7 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testCaseInsensitivePerformance() throws {
-        guard performance(0.032) else { return }
+        guard performance(expected: 0.032) else { return }
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["a", "b", "c", "d", "e" , "f", "g"] {
             router.register(route: Route(path: [
@@ -144,7 +144,7 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testCaseInsensitiveRoutingMatchFirstPerformance() throws {
-        guard performance(0.045) else { return }
+        guard performance(expected: 0.045) else { return }
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["aaaaaaaa", "aaaaaaab", "aaaaaaac", "aaaaaaad", "aaaaaaae" , "aaaaaaaf", "aaaaaaag"] {
             router.register(route: Route(path: [
@@ -162,7 +162,7 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testCaseInsensitiveRoutingMatchLastPerformance() throws {
-        guard performance(0.046) else { return }
+        guard performance(expected: 0.046) else { return }
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["aaaaaaaa", "aaaaaaab", "aaaaaaac", "aaaaaaad", "aaaaaaae" , "aaaaaaaf", "aaaaaaag"] {
             router.register(route: Route(path: [
@@ -180,7 +180,7 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testMinimalRouterCaseSensitivePerformance() throws {
-        guard performance(0.016) else { return }
+        guard performance(expected: 0.021) else { return }
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["a"] {
             router.register(route: Route(path: [
@@ -197,7 +197,7 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testMinimalRouterCaseInsensitivePerformance() throws {
-        guard performance(0.021) else { return }
+        guard performance(expected: 0.016) else { return }
         let router = TrieRouter.init(String.self)
         for letter in ["a"] {
             router.register(route: Route(path: [
@@ -215,7 +215,7 @@ public final class RouterTests: XCTestCase {
     
     
     public func testMinimalEarlyFailPerformance() throws {
-        guard performance(0.013) else { return }
+        guard performance(expected: 0.013) else { return }
         let router = TrieRouter.init(String.self)
         for letter in ["aaaaaaaaaaaaaa"] {
             router.register(route: Route(path: [
@@ -248,12 +248,13 @@ public final class RouterTests: XCTestCase {
     ]
 }
 
-func performance(_ seconds: Double) -> Bool {
+func performance(expected seconds: Double, name: String = #function) -> Bool {
     guard !_isDebugAssertConfiguration() else {
+        print("[PERFORMANCE] Skipping \(name) in debug build mode")
         return false
     }
     print()
-    print("[PERFORMANCE TEST] expected \(seconds) seconds")
+    print("[PERFORMANCE] \(name) expected: \(seconds) seconds")
     return true
 }
 

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -1,8 +1,8 @@
 import RoutingKit
 import XCTest
 
-class RouterTests: XCTestCase {
-    func testRouter() throws {
+public final class RouterTests: XCTestCase {
+    public func testRouter() throws {
         let route = Route(path: ["foo", "bar", "baz", User.parameter], output: 42)
         let router = TrieRouter(Int.self)
         router.register(route: route)
@@ -11,7 +11,7 @@ class RouterTests: XCTestCase {
         try XCTAssertEqual(params.next(User.self).name, "Tanner")
     }
     
-    func testCaseSensitiveRouting() throws {
+    public func testCaseSensitiveRouting() throws {
         let route = Route<Int>(path: [.constant("path"), .constant("TO"), .constant("fOo")], output: 42)
         let router = TrieRouter<Int>()
         router.register(route: route)
@@ -20,7 +20,7 @@ class RouterTests: XCTestCase {
         XCTAssertEqual(router.route(path: ["path", "TO", "fOo"], parameters: &params), 42)
     }
     
-    func testCaseInsensitiveRouting() throws {
+    public func testCaseInsensitiveRouting() throws {
         let route = Route<Int>(path: [.constant("path"), .constant("TO"), .constant("fOo")], output: 42)
         let router = TrieRouter<Int>(options: [.caseInsensitive])
         router.register(route: route)
@@ -28,7 +28,7 @@ class RouterTests: XCTestCase {
         XCTAssertEqual(router.route(path: ["PATH", "tO", "FOo"], parameters: &params), 42)
     }
 
-    func testAnyRouting() throws {
+    public func testAnyRouting() throws {
         let route0 = Route<Int>(path: [.constant("a"), any], output: 0)
         let route1 = Route<Int>(path: [.constant("b"), .parameter("1"), any], output: 1)
         let route2 = Route<Int>(path: [.constant("c"), .parameter("1"), .parameter("2"), any], output: 2)
@@ -64,7 +64,7 @@ class RouterTests: XCTestCase {
         XCTAssertEqual(router.route(path: ["g", "e", "1"], parameters: &params), 5)
     }
 
-    func testRouterSuffixes() throws {
+    public func testRouterSuffixes() throws {
         let route1 = Route<Int>(path: [.constant("a")], output: 1)
         let route2 = Route<Int>(path: [.constant("aa")], output: 2)
 
@@ -78,7 +78,7 @@ class RouterTests: XCTestCase {
     }
 
 
-    func testDocBlock() throws {
+    public func testDocBlock() throws {
         let route = Route<Int>(path: [.constant("users"), User.parameter], output: 42)
         let router = TrieRouter<Int>()
         router.register(route: route)
@@ -87,7 +87,7 @@ class RouterTests: XCTestCase {
         try XCTAssertEqual(params.next(User.self).name, "Tanner")
     }
 
-    func testDocs() throws {
+    public func testDocs() throws {
         let router = TrieRouter(Double.self)
         router.register(route: Route(path: ["fun", "meaning_of_universe"], output: 42))
         router.register(route: Route(path: ["fun", "leet"], output: 1337))
@@ -96,7 +96,7 @@ class RouterTests: XCTestCase {
         XCTAssertEqual(router.route(path: ["fun", "meaning_of_universe"], parameters: &params), 42)
     }
 
-    func testDocs2() throws {
+    public func testDocs2() throws {
         let router = TrieRouter(String.self)
         router.register(route: Route(path: [.constant("users"), .parameter("user_id")], output: "show_user"))
 
@@ -105,7 +105,7 @@ class RouterTests: XCTestCase {
         print(params)
     }
     
-    func testCaseSensitivePerformance() throws {
+    public func testCaseSensitivePerformance() throws {
         let router = TrieRouter(String.self)
         for letter in ["a", "b", "c", "d", "e" , "f", "g"] {
             router.register(route: Route(path: [
@@ -122,7 +122,7 @@ class RouterTests: XCTestCase {
         }
     }
     
-    func testCaseInsensitivePerformance() throws {
+    public func testCaseInsensitivePerformance() throws {
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["a", "b", "c", "d", "e" , "f", "g"] {
             router.register(route: Route(path: [
@@ -139,7 +139,7 @@ class RouterTests: XCTestCase {
         }
     }
     
-    func testCaseInsensitiveRoutingMatchFirstPerformance() throws {
+    public func testCaseInsensitiveRoutingMatchFirstPerformance() throws {
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["aaaaaaaa", "aaaaaaab", "aaaaaaac", "aaaaaaad", "aaaaaaae" , "aaaaaaaf", "aaaaaaag"] {
             router.register(route: Route(path: [
@@ -156,7 +156,7 @@ class RouterTests: XCTestCase {
         }
     }
     
-    func testCaseInsensitiveRoutingMatchLastPerformance() throws {
+    public func testCaseInsensitiveRoutingMatchLastPerformance() throws {
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["aaaaaaaa", "aaaaaaab", "aaaaaaac", "aaaaaaad", "aaaaaaae" , "aaaaaaaf", "aaaaaaag"] {
             router.register(route: Route(path: [
@@ -173,7 +173,7 @@ class RouterTests: XCTestCase {
         }
     }
     
-    func testMinimalRouterCaseSensitivePerformance() throws {
+    public func testMinimalRouterCaseSensitivePerformance() throws {
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["a"] {
             router.register(route: Route(path: [
@@ -189,7 +189,7 @@ class RouterTests: XCTestCase {
         }
     }
     
-    func testMinimalRouterCaseInsensitivePerformance() throws {
+    public func testMinimalRouterCaseInsensitivePerformance() throws {
         let router = TrieRouter.init(String.self)
         for letter in ["a"] {
             router.register(route: Route(path: [
@@ -206,7 +206,7 @@ class RouterTests: XCTestCase {
     }
     
     
-    func testMinimalEarlyFailPerformance() throws {
+    public func testMinimalEarlyFailPerformance() throws {
         let router = TrieRouter.init(String.self)
         for letter in ["aaaaaaaaaaaaaa"] {
             router.register(route: Route(path: [
@@ -223,7 +223,7 @@ class RouterTests: XCTestCase {
     }
 
 
-    static let allTests = [
+    public static let allTests = [
         ("testRouter", testRouter),
         ("testCaseInsensitiveRouting", testCaseInsensitiveRouting),
         ("testCaseSensitiveRouting", testCaseSensitiveRouting),

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -254,6 +254,7 @@ func performance(_ seconds: Double) -> Bool {
     }
     print()
     print("[PERFORMANCE TEST] expected \(seconds) seconds")
+    return true
 }
 
 final class User: Parameter {

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -92,7 +92,6 @@ class RouterTests: XCTestCase {
         router.register(route: Route(path: ["fun", "meaning_of_universe"], output: 42))
         router.register(route: Route(path: ["fun", "leet"], output: 1337))
         router.register(route: Route(path: ["math", "pi"], output: 3.14))
-
         var params = Parameters()
         XCTAssertEqual(router.route(path: ["fun", "meaning_of_universe"], parameters: &params), 42)
     }

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -105,7 +105,11 @@ public final class RouterTests: XCTestCase {
         print(params)
     }
     
+    // MARK: Performance
+    
     public func testCaseSensitivePerformance() throws {
+        print()
+        print("[EXPECTED] average: 0.024, relative standard deviation: 5.642%")
         let router = TrieRouter(String.self)
         for letter in ["a", "b", "c", "d", "e" , "f", "g"] {
             router.register(route: Route(path: [
@@ -123,6 +127,8 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testCaseInsensitivePerformance() throws {
+        print()
+        print("[EXPECTED] average: 0.032, relative standard deviation: 0.869%")
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["a", "b", "c", "d", "e" , "f", "g"] {
             router.register(route: Route(path: [
@@ -140,6 +146,8 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testCaseInsensitiveRoutingMatchFirstPerformance() throws {
+        print()
+        print("[EXPECTED] average: 0.045, relative standard deviation: 0.264%")
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["aaaaaaaa", "aaaaaaab", "aaaaaaac", "aaaaaaad", "aaaaaaae" , "aaaaaaaf", "aaaaaaag"] {
             router.register(route: Route(path: [
@@ -157,6 +165,8 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testCaseInsensitiveRoutingMatchLastPerformance() throws {
+        print()
+        print("[EXPECTED] average: 0.046, relative standard deviation: 0.086%")
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["aaaaaaaa", "aaaaaaab", "aaaaaaac", "aaaaaaad", "aaaaaaae" , "aaaaaaaf", "aaaaaaag"] {
             router.register(route: Route(path: [
@@ -174,6 +184,8 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testMinimalRouterCaseSensitivePerformance() throws {
+        print()
+        print("[EXPECTED] average: 0.016, relative standard deviation: 0.046%")
         let router = TrieRouter.init(String.self, options: [.caseInsensitive])
         for letter in ["a"] {
             router.register(route: Route(path: [
@@ -190,6 +202,8 @@ public final class RouterTests: XCTestCase {
     }
     
     public func testMinimalRouterCaseInsensitivePerformance() throws {
+        print()
+        print("[EXPECTED] average: 0.021, relative standard deviation: 0.800%")
         let router = TrieRouter.init(String.self)
         for letter in ["a"] {
             router.register(route: Route(path: [
@@ -207,6 +221,8 @@ public final class RouterTests: XCTestCase {
     
     
     public func testMinimalEarlyFailPerformance() throws {
+        print()
+        print("[EXPECTED] average: 0.013, relative standard deviation: 4.608%")
         let router = TrieRouter.init(String.self)
         for letter in ["aaaaaaaaaaaaaa"] {
             router.register(route: Route(path: [

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,12 @@ jobs:
     steps:
       - checkout
       - run: swift build -c release
+  linux-performance:
+    docker:
+      - image: vapor/swift:5.0
+    steps:
+      - checkout
+      - run: swift test -c release
 
 workflows:
   version: 2
@@ -21,3 +27,4 @@ workflows:
     jobs:
       - linux
       - linux-release
+      - linux-performance


### PR DESCRIPTION
This removes `TrieRouter.Node.value` to reduce memory footprint of `TrieRouter`. 